### PR TITLE
fix: Starlark script execution, header support, and request lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Compiled binaries
-galick
-main
+/galick
 bin/
 *.exe
 *.dll

--- a/cmd/galick/main.go
+++ b/cmd/galick/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -33,6 +34,7 @@ var (
 	timeout    time.Duration
 	headless   bool
 	insecure   bool
+	rawHeaders []string
 )
 
 func main() {
@@ -58,7 +60,7 @@ Examples:
 			var err error
 
 			if scriptPath != "" {
-				attacker, err = script.NewScriptAttacker(scriptPath, timeout, insecure)
+				attacker, err = script.NewScriptAttacker(scriptPath, timeout, insecure, workers)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error loading script: %v\n", err)
 					os.Exit(1)
@@ -68,7 +70,21 @@ Examples:
 					fmt.Fprintln(os.Stderr, "Error: --url is required unless --script is provided")
 					os.Exit(1)
 				}
-				attacker = loadhttp.NewAttacker(method, targetURL, timeout, insecure)
+				headers := make(map[string]string)
+				for _, h := range rawHeaders {
+					k, v, ok := strings.Cut(h, ":")
+					if !ok {
+						fmt.Fprintf(os.Stderr, "Error: invalid header format %q (expected Key:Value)\n", h)
+						os.Exit(1)
+					}
+					key := strings.TrimSpace(k)
+					if key == "" {
+						fmt.Fprintf(os.Stderr, "Error: invalid header: key cannot be empty in %q\n", h)
+						os.Exit(1)
+					}
+					headers[key] = strings.TrimSpace(v)
+				}
+				attacker = loadhttp.NewAttacker(method, targetURL, timeout, insecure, headers, workers)
 			}
 
 			// Initialize Engine
@@ -127,6 +143,7 @@ Examples:
 	rootCmd.Flags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "Timeout for each request")
 	rootCmd.Flags().BoolVar(&headless, "headless", false, "Run without TUI (useful for CI/Docker)")
 	rootCmd.Flags().BoolVarP(&insecure, "insecure", "k", false, "Skip TLS certificate verification")
+	rootCmd.Flags().StringArrayVarP(&rawHeaders, "header", "H", nil, "Custom header (e.g. -H 'Content-Type:application/json')")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Execution failed: %v\n", err)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -47,19 +47,17 @@ func (e *Engine) Run(ctx context.Context) {
 	ticks := make(chan struct{})
 
 	// Start workers
-	// Each worker waits for a tick and performs an attack
+	// Each worker waits for a tick and performs an attack.
+	// Workers use ctx (not runCtx) for Attack so that in-flight requests
+	// are not cancelled when the test duration expires. The HTTP client's
+	// own timeout handles per-request deadlines.
 	for i := 0; i < e.workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for {
-				select {
-				case <-runCtx.Done():
-					return
-				case <-ticks:
-					res := e.attacker.Attack(runCtx)
-					e.stats.Add(res)
-				}
+			for range ticks {
+				res := e.attacker.Attack(ctx)
+				e.stats.Add(res)
 			}
 		}()
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,5 +1,5 @@
 // Package metrics provides thread-safe statistics collection and reporting.
-package metrics
+package metrics //nolint:revive // metrics is the canonical name for this package
 
 import (
 	"sync"

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,20 +1,22 @@
-package metrics
+package metrics_test
 
 import (
 	"testing"
 	"time"
+
+	"github.com/kanywst/galick/pkg/metrics"
 )
 
 func TestStats(t *testing.T) {
-	s := NewStats()
+	s := metrics.NewStats()
 
 	// Add some dummy data
-	s.Add(Result{
+	s.Add(metrics.Result{
 		Latency:  10 * time.Millisecond,
 		BytesIn:  100,
 		Code:     200,
 	})
-	s.Add(Result{
+	s.Add(metrics.Result{
 		Latency:  20 * time.Millisecond,
 		BytesIn:  200,
 		Code:     500,

--- a/pkg/protocols/loadhttp/http.go
+++ b/pkg/protocols/loadhttp/http.go
@@ -14,26 +14,33 @@ import (
 
 // Attacker implements the Attacker interface for HTTP.
 type Attacker struct {
-	client *http.Client
-	method string
-	url    string
+	client  *http.Client
+	method  string
+	url     string
+	headers map[string]string
 }
 
 // NewAttacker creates a new HTTP Attacker.
-func NewAttacker(method, url string, timeout time.Duration, insecure bool) protocols.Attacker {
+func NewAttacker(method, url string, timeout time.Duration, insecure bool, headers map[string]string, workers int) protocols.Attacker {
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		MaxIdleConns:    1000,
-		MaxConnsPerHost: 1000,
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: insecure},
+		MaxIdleConns:       workers,
+		MaxIdleConnsPerHost: workers,
 	}
-	
+
+	copiedHeaders := make(map[string]string, len(headers))
+	for k, v := range headers {
+		copiedHeaders[k] = v
+	}
+
 	return &Attacker{
 		client: &http.Client{
 			Transport: tr,
 			Timeout:   timeout,
 		},
-		method: method,
-		url:    url,
+		method:  method,
+		url:     url,
+		headers: copiedHeaders,
 	}
 }
 
@@ -53,6 +60,10 @@ func (h *Attacker) Attack(ctx context.Context) metrics.Result {
 			Error:     err.Error(),
 			Latency:   time.Since(start),
 		}
+	}
+
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := h.client.Do(req)

--- a/pkg/protocols/loadhttp/http_test.go
+++ b/pkg/protocols/loadhttp/http_test.go
@@ -1,0 +1,76 @@
+package loadhttp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kanywst/galick/pkg/protocols/loadhttp"
+)
+
+func TestAttacker_NoHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := loadhttp.NewAttacker("GET", srv.URL, 5*time.Second, false, nil, 2)
+	res := a.Attack(context.Background())
+
+	if res.Code != 200 {
+		t.Errorf("expected 200, got %d", res.Code)
+	}
+	if res.Error != "" {
+		t.Errorf("unexpected error: %s", res.Error)
+	}
+}
+
+func TestAttacker_WithHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	headers := map[string]string{
+		"Authorization": "Bearer test-token",
+		"Content-Type":  "application/json",
+	}
+	a := loadhttp.NewAttacker("GET", srv.URL, 5*time.Second, false, headers, 2)
+	res := a.Attack(context.Background())
+
+	if res.Code != 200 {
+		t.Errorf("expected 200, got %d (headers not applied)", res.Code)
+	}
+	if res.Error != "" {
+		t.Errorf("unexpected error: %s", res.Error)
+	}
+}
+
+func TestAttacker_MissingHeaders_Rejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// No headers — server should reject
+	a := loadhttp.NewAttacker("GET", srv.URL, 5*time.Second, false, nil, 2)
+	res := a.Attack(context.Background())
+
+	if res.Code != 401 {
+		t.Errorf("expected 401 without auth header, got %d", res.Code)
+	}
+}

--- a/pkg/protocols/script/script.go
+++ b/pkg/protocols/script/script.go
@@ -23,7 +23,7 @@ type Attacker struct {
 }
 
 // NewScriptAttacker creates a new Starlark script attacker.
-func NewScriptAttacker(scriptPath string, timeout time.Duration, insecure bool) (protocols.Attacker, error) {
+func NewScriptAttacker(scriptPath string, timeout time.Duration, insecure bool, workers int) (protocols.Attacker, error) {
 	thread := &starlark.Thread{Name: "main"}
 	opts := &syntax.FileOptions{}
 	globals, err := starlark.ExecFileOptions(opts, thread, scriptPath, nil, nil)
@@ -37,9 +37,9 @@ func NewScriptAttacker(scriptPath string, timeout time.Duration, insecure bool) 
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		MaxIdleConns:    1000,
-		MaxConnsPerHost: 1000,
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: insecure},
+		MaxIdleConns:       workers,
+		MaxIdleConnsPerHost: workers,
 	}
 
 	return &Attacker{
@@ -56,59 +56,115 @@ func (s *Attacker) Name() string {
 	return "script"
 }
 
-// Attack performs a single request by executing the Starlark script.
-func (s *Attacker) Attack(ctx context.Context) metrics.Result {
-	start := time.Now()
+// requestSpec holds the parsed fields from a Starlark request() return value.
+type requestSpec struct {
+	method  string
+	url     string
+	body    io.Reader
+	headers *starlark.Dict
+}
 
-	thread := &starlark.Thread{Name: "worker"}
-	
-	res, err := starlark.Call(thread, s.requestFn, nil, nil)
-	if err != nil {
-		return metrics.Result{Timestamp: start, Error: fmt.Sprintf("script error: %v", err), Latency: time.Since(start)}
-	}
-
-	dict, ok := res.(*starlark.Dict)
-	if !ok {
-		return metrics.Result{Timestamp: start, Error: "script must return a dict", Latency: time.Since(start)}
-	}
-
-	method := "GET"
-	url := ""
-	var body io.Reader
-
+// parseRequestDict extracts method, url, body, and headers from a Starlark dict.
+func parseRequestDict(dict *starlark.Dict) (requestSpec, error) {
+	spec := requestSpec{method: "GET"}
 	for _, item := range dict.Items() {
 		k, ok := item[0].(starlark.String)
 		if !ok {
 			continue
 		}
-		switch k.String() {
+		switch k.GoString() {
 		case "method":
-			if v, ok := item[1].(starlark.String); ok {
-				method = string(v)
+			v, ok := item[1].(starlark.String)
+			if !ok {
+				return spec, fmt.Errorf("script returned 'method' with non-string value")
 			}
+			spec.method = v.GoString()
 		case "url":
-			if v, ok := item[1].(starlark.String); ok {
-				url = string(v)
+			v, ok := item[1].(starlark.String)
+			if !ok {
+				return spec, fmt.Errorf("script returned 'url' with non-string value")
 			}
+			spec.url = v.GoString()
 		case "body":
-			if v, ok := item[1].(starlark.String); ok {
-				body = strings.NewReader(string(v))
+			v, ok := item[1].(starlark.String)
+			if !ok {
+				return spec, fmt.Errorf("script returned 'body' with non-string value")
 			}
+			spec.body = strings.NewReader(v.GoString())
+		case "headers":
+			v, ok := item[1].(*starlark.Dict)
+			if !ok {
+				return spec, fmt.Errorf("script returned 'headers' with non-dict value")
+			}
+			spec.headers = v
 		}
 	}
+	return spec, nil
+}
 
-	if url == "" {
-		return metrics.Result{Timestamp: start, Error: "script returned empty url", Latency: time.Since(start)}
+// applyHeaders sets headers from a Starlark dict onto an http.Request.
+func applyHeaders(req *http.Request, headers *starlark.Dict) error {
+	for _, item := range headers.Items() {
+		k, ok := item[0].(starlark.String)
+		if !ok {
+			return fmt.Errorf("script returned header with non-string key")
+		}
+		v, ok := item[1].(starlark.String)
+		if !ok {
+			return fmt.Errorf("script returned header with non-string value")
+		}
+		keyStr := k.GoString()
+		if keyStr == "" {
+			return fmt.Errorf("script returned header with empty key")
+		}
+		req.Header.Set(keyStr, v.GoString())
+	}
+	return nil
+}
+
+// errResult creates an error metrics.Result from the given start time and message.
+func errResult(start time.Time, msg string) metrics.Result {
+	return metrics.Result{Timestamp: start, Error: msg, Latency: time.Since(start)}
+}
+
+// Attack performs a single request by executing the Starlark script.
+func (s *Attacker) Attack(ctx context.Context) metrics.Result {
+	start := time.Now()
+
+	thread := &starlark.Thread{Name: "worker"}
+
+	res, err := starlark.Call(thread, s.requestFn, nil, nil)
+	if err != nil {
+		return errResult(start, fmt.Sprintf("script error: %v", err))
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	dict, ok := res.(*starlark.Dict)
+	if !ok {
+		return errResult(start, "script must return a dict")
+	}
+
+	spec, err := parseRequestDict(dict)
 	if err != nil {
-		return metrics.Result{Timestamp: start, Error: err.Error(), Latency: time.Since(start)}
+		return errResult(start, err.Error())
+	}
+	if spec.url == "" {
+		return errResult(start, "script returned empty url")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, spec.method, spec.url, spec.body)
+	if err != nil {
+		return errResult(start, err.Error())
+	}
+
+	if spec.headers != nil {
+		if err := applyHeaders(req, spec.headers); err != nil {
+			return errResult(start, err.Error())
+		}
 	}
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return metrics.Result{Timestamp: start, Error: err.Error(), Latency: time.Since(start)}
+		return errResult(start, err.Error())
 	}
 	defer func() {
 		_ = resp.Body.Close()

--- a/pkg/protocols/script/script_test.go
+++ b/pkg/protocols/script/script_test.go
@@ -1,0 +1,121 @@
+package script_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kanywst/galick/pkg/protocols/script"
+)
+
+func writeStarFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.star")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write star file: %v", err)
+	}
+	return path
+}
+
+func TestScriptAttacker_WithHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "hello" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer abc" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	starScript := `
+def request():
+    return {
+        "method": "GET",
+        "url": "` + srv.URL + `",
+        "headers": {
+            "X-Custom": "hello",
+            "Authorization": "Bearer abc",
+        },
+    }
+`
+	path := writeStarFile(t, starScript)
+	a, err := script.NewScriptAttacker(path, 5*time.Second, false, 2)
+	if err != nil {
+		t.Fatalf("failed to create attacker: %v", err)
+	}
+
+	res := a.Attack(context.Background())
+
+	if res.Code != 200 {
+		t.Errorf("expected 200, got %d (headers not applied)", res.Code)
+	}
+	if res.Error != "" {
+		t.Errorf("unexpected error: %s", res.Error)
+	}
+}
+
+func TestScriptAttacker_NoHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	starScript := `
+def request():
+    return {
+        "method": "GET",
+        "url": "` + srv.URL + `",
+    }
+`
+	path := writeStarFile(t, starScript)
+	a, err := script.NewScriptAttacker(path, 5*time.Second, false, 2)
+	if err != nil {
+		t.Fatalf("failed to create attacker: %v", err)
+	}
+
+	res := a.Attack(context.Background())
+
+	if res.Code != 200 {
+		t.Errorf("expected 200, got %d", res.Code)
+	}
+}
+
+func TestScriptAttacker_HeadersRequired_Missing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Script without headers — server should reject
+	starScript := `
+def request():
+    return {
+        "method": "GET",
+        "url": "` + srv.URL + `",
+    }
+`
+	path := writeStarFile(t, starScript)
+	a, err := script.NewScriptAttacker(path, 5*time.Second, false, 2)
+	if err != nil {
+		t.Fatalf("failed to create attacker: %v", err)
+	}
+
+	res := a.Attack(context.Background())
+
+	if res.Code != 401 {
+		t.Errorf("expected 401 without auth header, got %d", res.Code)
+	}
+}

--- a/pkg/report/tui.go
+++ b/pkg/report/tui.go
@@ -96,11 +96,11 @@ func (m Model) View() string {
 	s.WriteString("\n  Galick Load Test Running...\n\n")
 	
 	// Stats Grid
-	s.WriteString(fmt.Sprintf("  Requests: %d\n", stats.TotalRequests))
-	s.WriteString(fmt.Sprintf("  Success:  %d\n", stats.SuccessCount))
-	s.WriteString(fmt.Sprintf("  Errors:   %d\n", stats.ErrorCount))
-	s.WriteString(fmt.Sprintf("  QPS:      %.2f\n", currentQPS))
-	s.WriteString(fmt.Sprintf("  P99:      %v\n", stats.P99()))
+	fmt.Fprintf(&s, "  Requests: %d\n", stats.TotalRequests)
+	fmt.Fprintf(&s, "  Success:  %d\n", stats.SuccessCount)
+	fmt.Fprintf(&s, "  Errors:   %d\n", stats.ErrorCount)
+	fmt.Fprintf(&s, "  QPS:      %.2f\n", currentQPS)
+	fmt.Fprintf(&s, "  P99:      %v\n", stats.P99())
 	s.WriteString("\n")
 	
 	s.WriteString("  " + m.progress.View() + "\n")
@@ -132,20 +132,20 @@ func GenerateTextReport(eng *engine.Engine, start time.Time) string {
 	s.WriteString("\n")
 	s.WriteString(style.Render(" TEST COMPLETED "))
 	s.WriteString("\n\n")
-	s.WriteString(fmt.Sprintf("  Duration:   %v\n", elapsed))
-	s.WriteString(fmt.Sprintf("  Requests:   %d\n", stats.TotalRequests))
-	s.WriteString(fmt.Sprintf("  Mean QPS:   %.2f\n", avgQPS))
+	fmt.Fprintf(&s, "  Duration:   %v\n", elapsed)
+	fmt.Fprintf(&s, "  Requests:   %d\n", stats.TotalRequests)
+	fmt.Fprintf(&s, "  Mean QPS:   %.2f\n", avgQPS)
 	if stats.TotalRequests > 0 {
-		s.WriteString(fmt.Sprintf("  Success:    %.2f%%\n", float64(stats.SuccessCount)/float64(stats.TotalRequests)*100))
+		fmt.Fprintf(&s, "  Success:    %.2f%%\n", float64(stats.SuccessCount)/float64(stats.TotalRequests)*100)
 	} else {
 		s.WriteString("  Success:    0.00%\n")
 	}
-	
+
 	if stats.TotalRequests > 0 {
-		s.WriteString(fmt.Sprintf("  P50 Latency: %v\n", time.Duration(stats.Histogram.ValueAtQuantile(50))*time.Microsecond))
-		s.WriteString(fmt.Sprintf("  P95 Latency: %v\n", stats.P95()))
-		s.WriteString(fmt.Sprintf("  P99 Latency: %v\n", stats.P99()))
-		s.WriteString(fmt.Sprintf("  Max Latency: %v\n", stats.Max()))
+		fmt.Fprintf(&s, "  P50 Latency: %v\n", time.Duration(stats.Histogram.ValueAtQuantile(50))*time.Microsecond)
+		fmt.Fprintf(&s, "  P95 Latency: %v\n", stats.P95())
+		fmt.Fprintf(&s, "  P99 Latency: %v\n", stats.P99())
+		fmt.Fprintf(&s, "  Max Latency: %v\n", stats.Max())
 	}
 	s.WriteString("\n")
 


### PR DESCRIPTION
## Summary

- Fix Starlark dict key parsing (`String()` → `GoString()`) — all script-based requests were silently failing
- Add header support: `"headers"` dict in Starlark scripts + `--header`/`-H` CLI flag for static mode
- Fix in-flight requests cancelled on duration expiry by separating pacing context from request context
- Fix pre-existing lint warnings, add 6 unit tests

## Manual verification

### 1. Build

```bash
make build
```

### 2. Starlark script mode (examples/attack.star)

```bash
./galick --script examples/attack.star --qps 5 --duration 3s --workers 2 --headless
# → Success: 100.00% (was 0% before fix)
```

### 3. Static mode with --header flag

```bash
./galick --url https://httpbin.org/get --qps 5 --duration 3s --workers 2 --headless -H 'Accept:application/json'
# → Success: 100.00%
```

### 4. Static mode without headers (regression check)

```bash
./galick --url https://httpbin.org/get --qps 5 --duration 3s --workers 2 --headless
# → Success: 100.00%
```
